### PR TITLE
Avoid exception on empty e-mail body

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ module.exports = EmlParser = function (fileReadStream) {
             this.parseEml()
                 .then(result => {
                     let htmlString = result.html;
+                    if (!htmlString) {
+                        resolve('');
+                    }
                     for (var key in replacements) {
                         let re = new RegExp(key, 'gi')
                         htmlString = htmlString.replace(re, replacements[key]);


### PR DESCRIPTION
Currently, if the body is empty the result.html is empty it will be a boolean flag, and that makes the replace not to work and throw exception.