### PR TITLE
chore: add .npmignore for clean npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Dev & CI files — not needed by consumers
+.github/
+.eslintrc.cjs
+eslint.config.cjs
+.prettierrc
+tsconfig.json
+ROADMAP.md
+CHANGELOG.md
+test/
+sample/


### PR DESCRIPTION
Add `.npmignore` to exclude dev/CI files from the published npm package.

**Before:** 13 files, 12.9 KB
**After:** 5 files (LICENSE, README.md, index.d.ts, index.js, package.json), 8.8 KB